### PR TITLE
Add Jest tests for canStartGame

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dvd-screensaver-game",
+  "version": "1.0.0",
+  "description": "A modern, neon-styled browser game inspired by the classic DVD screensaver, where players compete to see whose logo hits a screen corner first.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest --config tests/jest.config.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/canStartGame.test.js
+++ b/tests/canStartGame.test.js
@@ -1,0 +1,28 @@
+const { JSDOM } = require('jsdom');
+
+describe('canStartGame', () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!DOCTYPE html><input id="player1" />', { runScripts: 'dangerously' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    jest.resetModules();
+    require('../script.js');
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+  });
+
+  test('returns false when the input is empty', () => {
+    expect(DVDCornerChallenge.prototype.canStartGame()).toBe(false);
+  });
+
+  test('returns true when the input is populated', () => {
+    document.getElementById('player1').value = 'Alice';
+    expect(DVDCornerChallenge.prototype.canStartGame()).toBe(true);
+  });
+});

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/tests']
+};


### PR DESCRIPTION
## Summary
- set up Jest configuration in `tests/jest.config.js`
- add `npm` metadata with Jest and jsdom deps
- write `canStartGame` unit test using JSDOM

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d04c2930832ebd0303af5034a65d