### PR TITLE
Fix Enter key behavior and update start condition

### DIFF
--- a/script.js
+++ b/script.js
@@ -204,9 +204,9 @@ class DVDCornerChallenge {
                         e.preventDefault();
                         this.toggleSound();
                     }
-                    // ENTER starts game if not in input
+                    // ENTER starts game if not in input and game hasn't started
                     if (e.key === 'Enter' && (!active || active.tagName !== 'INPUT')) {
-                        if (this.canStartGame()) this.startGame();
+                        if (!this.state.gameStarted && this.canStartGame()) this.startGame();
                     }
                 });
                 
@@ -279,7 +279,7 @@ class DVDCornerChallenge {
                         });
                         
                         input.addEventListener('keypress', (e) => {
-                            if (e.key === 'Enter' && this.canStartGame()) {
+                            if (e.key === 'Enter' && !this.state.gameStarted && this.canStartGame()) {
                                 this.startGame();
                             }
                         });
@@ -293,9 +293,16 @@ class DVDCornerChallenge {
                 this.elements.buttons.start.disabled = !this.canStartGame();
                 this.elements.buttons.addPlayer.disabled = this.state.currentPlayerCount >= this.state.maxPlayers;
             }
-            
+
             canStartGame() {
-                return document.getElementById('player1')?.value.trim() !== '';
+                const inputs = document.querySelectorAll('input[id^="player"]');
+                let filled = 0;
+                inputs.forEach(input => {
+                    if (input.value && input.value.trim() !== '') {
+                        filled++;
+                    }
+                });
+                return filled >= 2;
             }
             
             addPlayer() {
@@ -316,7 +323,7 @@ class DVDCornerChallenge {
             }
             
             startGame() {
-                if (!this.canStartGame()) return;
+                if (this.state.gameStarted || !this.canStartGame()) return;
                 this.elements.gameSetup.classList.add('hidden');
                 this.elements.gameStats.classList.add('show');
                 // Show/hide correct buttons

--- a/tests/canStartGame.test.js
+++ b/tests/canStartGame.test.js
@@ -4,7 +4,7 @@ describe('canStartGame', () => {
   let dom;
 
   beforeEach(() => {
-    dom = new JSDOM('<!DOCTYPE html><input id="player1" />', { runScripts: 'dangerously' });
+    dom = new JSDOM('<!DOCTYPE html><input id="player1" /><input id="player2" />', { runScripts: 'dangerously' });
     global.window = dom.window;
     global.document = dom.window.document;
     jest.resetModules();
@@ -17,12 +17,13 @@ describe('canStartGame', () => {
     delete global.document;
   });
 
-  test('returns false when the input is empty', () => {
+  test('returns false when less than two names are entered', () => {
     expect(DVDCornerChallenge.prototype.canStartGame()).toBe(false);
   });
 
-  test('returns true when the input is populated', () => {
+  test('returns true when two names are entered', () => {
     document.getElementById('player1').value = 'Alice';
+    document.getElementById('player2').value = 'Bob';
     expect(DVDCornerChallenge.prototype.canStartGame()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- fix Enter key from spawning extra logos
- require at least two players to start the game
- prevent Enter from starting the game during gameplay
- update unit tests for `canStartGame`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d3a32b1c832eb245b4fee9629b0f