### PR TITLE
Adjust slider display

### DIFF
--- a/dvd-screensaver-game.html
+++ b/dvd-screensaver-game.html
@@ -29,22 +29,16 @@
         </div>
         <div class="controls-container">
             <div class="control-group">
-                <div class="control-label">Game Speed</div>
+                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">3</span></div>
                 <div class="slider-container">
-                    <span class="range-label">1</span>
                     <input type="range" id="speed-slider" class="game-slider" min="1" max="5" value="3" step="1">
-                    <span class="range-label">5</span>
                 </div>
-                <div class="control-value" id="current-speed">3</div>
             </div>
             <div class="control-group">
-                <div class="control-label">Logo Size</div>
+                <div class="control-label">Logo Size: <span class="control-value" id="current-size">3</span></div>
                 <div class="slider-container">
-                    <span class="range-label">1</span>
                     <input type="range" id="size-slider" class="game-slider" min="1" max="5" value="3" step="1">
-                    <span class="range-label">5</span>
                 </div>
-                <div class="control-value" id="current-size">3</div>
             </div>
         </div>
         <div class="button-container">


### PR DESCRIPTION
## Summary
- remove numeric range labels from sliders
- show slider values inline with the label

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d573a20c832ea950a1b92a768491