### PR TITLE
Fix inconsistent pre-game speed

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,7 +61,9 @@ class DVDCornerChallenge {
                 
                 // Game configuration
                 this.config = {
-                    basePreviewSpeed: 4,
+                    // Use the same base speed for previews and gameplay so
+                    // there is no noticeable speed change when the game starts
+                    basePreviewSpeed: 6,
                     baseGameSpeed: 6,
                     speedMultiplier: 3, // Default speed (slider value 3)
                     baseLogo: { width: 200, height: 88 },


### PR DESCRIPTION
## Summary
- keep preview and in-game logo speeds identical

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d7f0e470832e9936cb601c34d76a