### PR TITLE
Respawn player previews after end

### DIFF
--- a/script.js
+++ b/script.js
@@ -693,8 +693,10 @@ class DVDCornerChallenge {
                 this.elements.gameStats.classList.remove('show');
                 this.elements.gameStats.innerHTML = '';
                 this.elements.gameSetup.classList.remove('hidden');
+                this.respawnPreviewLogos();
+                this.updateButtons();
             }
-            
+
             restartGame() {
                 this.cleanupPlayers();
                 this.clearPreviewLogos();
@@ -712,7 +714,7 @@ class DVDCornerChallenge {
                 this.elements.gameStats.classList.remove('show');
                 this.elements.gameSetup.classList.remove('hidden');
                 this.elements.gameStats.innerHTML = '';
-                this.resetPlayerInputs();
+                this.respawnPreviewLogos();
                 this.updateButtons();
             }
             
@@ -737,6 +739,16 @@ class DVDCornerChallenge {
                     if (prev) prev.cancelled = true;
                 }
                 this.state.previewLogos = [];
+            }
+
+            respawnPreviewLogos() {
+                this.clearPreviewLogos();
+                for (let i = 1; i <= this.state.currentPlayerCount; i++) {
+                    const input = document.getElementById(`player${i}`);
+                    if (input && input.value.trim()) {
+                        this.updatePreviewLogo(i, input.value.trim());
+                    }
+                }
             }
             
             resetPlayerInputs() {


### PR DESCRIPTION
## Summary
- keep player names after stopping or restarting the game
- respawn preview logos from the current input values on Stop Game or Play Again

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843dac45918832ea95cd9df5b07da0b