### PR TITLE
Improve mobile layout with responsive CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -780,3 +780,69 @@ body {
     }
 }
 
+
+@media (max-width: 600px) {
+    :root {
+        --button-height: 50px;
+        --button-width: 160px;
+        --border-width: 2px;
+    }
+    .arcade-button {
+        font-size: 14px;
+    }
+    .arcade-button--primary {
+        font-size: 18px;
+    }
+    #fullscreen-btn {
+        width: 40px;
+        height: 40px;
+        font-size: 12px;
+    }
+    .bottom-buttons button,
+    #bottom-action-buttons button,
+    #stop-game-btn,
+    #restart-btn,
+    #sound-toggle-btn {
+        width: 160px;
+        min-width: 160px;
+        height: 50px;
+        font-size: 14px;
+    }
+    .player-inputs {
+        grid-template-columns: 1fr;
+    }
+    .controls-container {
+        flex-direction: column;
+        gap: 30px;
+    }
+    .game-slider {
+        width: 140px;
+    }
+    .control-label,
+    .player-input label {
+        font-size: 14px;
+    }
+    .player-input input {
+        width: 180px;
+        padding: 10px 15px;
+        font-size: 14px;
+    }
+    .control-value {
+        font-size: 16px;
+    }
+    .winner-title {
+        font-size: 40px;
+    }
+    .winner-name {
+        font-size: 48px;
+    }
+    #winner-logo-display,
+    .winner-logo-container {
+        width: 240px;
+        height: 240px;
+    }
+    .winner-logo {
+        width: 200px;
+    }
+}
+


### PR DESCRIPTION
## Summary
- shrink controls and layout on small screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843efe383d4832e85913189541a3873