### PR TITLE
Focus cursor on default player text

### DIFF
--- a/script.js
+++ b/script.js
@@ -808,5 +808,12 @@ class DVDCornerChallenge {
             if (p1) {
                 game.updatePreviewLogo(1, p1.value.trim());
                 p1.focus();
+                // Place cursor at end of default text for quick deletion
+                const len = p1.value.length;
+                try {
+                    p1.setSelectionRange(len, len);
+                } catch (e) {
+                    // Some older browsers may not support setSelectionRange
+                }
             }
         });


### PR DESCRIPTION
## Summary
- keep default player name GOOD VIBES when page loads
- place typing cursor at the end of that text so it's easy to delete

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eefedd04832e802898066283beb8