### PR TITLE
Improve small-screen mobile compatibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -247,8 +247,9 @@ class DVDCornerChallenge {
             }
             
             updateSizes() {
-                this.config.logoWidth = this.config.baseLogo.width * this.config.sizeMultiplier * 0.5;
-                this.config.logoHeight = this.config.baseLogo.height * this.config.sizeMultiplier * 0.5;
+                const scale = window.innerWidth < 400 ? 0.35 : 0.5;
+                this.config.logoWidth = this.config.baseLogo.width * this.config.sizeMultiplier * scale;
+                this.config.logoHeight = this.config.baseLogo.height * this.config.sizeMultiplier * scale;
             }
             
             updatePreviewSpeeds() {

--- a/style.css
+++ b/style.css
@@ -850,3 +850,61 @@ body {
     }
 }
 
+@media (max-width: 400px) {
+    :root {
+        --button-height: 40px;
+        --button-width: 120px;
+        --border-width: 2px;
+    }
+    .arcade-button {
+        font-size: 12px;
+    }
+    .arcade-button--primary {
+        font-size: 16px;
+    }
+    #fullscreen-btn {
+        width: 30px;
+        height: 30px;
+        font-size: 10px;
+    }
+    .bottom-buttons button,
+    #bottom-action-buttons button,
+    #stop-game-btn,
+    #restart-btn,
+    #sound-toggle-btn {
+        width: 120px;
+        min-width: 120px;
+        height: 40px;
+        font-size: 12px;
+    }
+    .game-slider {
+        width: 120px;
+    }
+    .control-label,
+    .player-input label {
+        font-size: 12px;
+    }
+    .player-input input {
+        width: 150px;
+        padding: 8px 12px;
+        font-size: 12px;
+    }
+    .control-value {
+        font-size: 14px;
+    }
+    .winner-title {
+        font-size: 32px;
+    }
+    .winner-name {
+        font-size: 40px;
+    }
+    #winner-logo-display,
+    .winner-logo-container {
+        width: 200px;
+        height: 200px;
+    }
+    .winner-logo {
+        width: 160px;
+    }
+}
+


### PR DESCRIPTION
## Summary
- tweak mobile layout by adding a 400px media query
- scale game logo size dynamically for tiny screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f5e5916c832eb0225f63b252f70d