### PR TITLE
Fix UI visibility after win

### DIFF
--- a/script.js
+++ b/script.js
@@ -669,6 +669,11 @@ class DVDCornerChallenge {
             }
             
             showWinnerScreen(winner) {
+                // Ensure UI is visible when showing the winner screen
+                this.state.uiHidden = false;
+                this.elements.bottomButtons.classList.remove('ui-hidden');
+                this.elements.gameStats.classList.remove('ui-hidden');
+
                 // Show the overlay
                 this.elements.winnerOverlay.classList.add('show');
                 this.elements.winnerOverlay.classList.add('winner-animation');


### PR DESCRIPTION
## Summary
- ensure play again button appears by unhiding UI on the winner screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f734f120832eb0ed64d94eb27b77