### PR TITLE
Refine speed knob defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A neon-soaked browser game inspired by the classic DVD screensaver. Open `index.
 - **Corner Hit Showdown:** First logo to hit any corner wins the round.
 - **Live Logo Preview:** See your logo bounce around as you type your name.
 - **Custom Game Settings:**
-  - **Speed:** Crank it up or slow it down (1-5).
+  - **Speed:** Crank it up or slow it down with an 11-position knob (default at 6).
   - **Logo Size:** Make your logo huge or keep it classic (1-5).
 - **Neon Arcade UI:** Flashy, animated buttons and overlays with glowing effects.
 - **Fullscreen Mode:** Go immersive with 'F'.

--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
         </div>
         <div class="controls-container">
             <div class="control-group">
-                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">3</span></div>
+                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">1</span></div>
                 <div class="slider-container">
-                    <input type="range" id="speed-slider" class="game-slider" min="1" max="11" value="3" step="1">
+                    <input type="range" id="speed-slider" class="game-slider" min="1" max="11" value="6" step="1">
                 </div>
             </div>
             <div class="control-group">

--- a/script.js
+++ b/script.js
@@ -1,7 +1,8 @@
 class DVDCornerChallenge {
             constructor() {
-                this.MIN_SPEED = 1; // Speed when the slider is at 1
-                this.MAX_SPEED = 20; // Speed when the slider is at 11
+                this.MIN_SPEED = 0.01; // Speed when the knob is at 1
+                this.MAX_SPEED = 20; // Speed when the knob is at 11
+                this.DEFAULT_KNOB = 6; // Default knob position (speed 1)
                 this.initializeElements();
                 this.initializeGame();
                 this.setupEventListeners();
@@ -64,8 +65,8 @@ class DVDCornerChallenge {
                 
                 // Game configuration
                 this.config = {
-                    // Slider value for speed control (1-11)
-                    speedMultiplier: 3, // Default speed (slider value 3)
+                    // Slider knob position (1-11)
+                    speedKnob: this.DEFAULT_KNOB,
                     baseLogo: { width: 200, height: 88 },
                     sizeMultiplier: 3, // Default size (slider value 3)
                     logoWidth: 200,
@@ -80,6 +81,9 @@ class DVDCornerChallenge {
                 // Initialize audio context
                 this.initializeAudio();
                 
+                // Sync sliders with configured defaults
+                this.elements.speedSlider.value = this.config.speedKnob;
+
                 this.updateSpeeds();
                 this.updateSizes();
             }
@@ -108,6 +112,21 @@ class DVDCornerChallenge {
                     const cross = icon.querySelector('#sound-x') || icon.querySelector('#sound-x-setup');
                     if (cross) cross.style.display = this.soundEnabled ? 'none' : 'inline';
                 });
+            }
+
+            knobToSpeed(k) {
+                const DEFAULT_SPEED = 1;
+                if (k <= this.DEFAULT_KNOB) {
+                    const stepsBelow = this.DEFAULT_KNOB - 1;
+                    return this.MIN_SPEED + (k - 1) * (DEFAULT_SPEED - this.MIN_SPEED) / stepsBelow;
+                }
+                const stepsAbove = 11 - this.DEFAULT_KNOB;
+                return DEFAULT_SPEED + (k - this.DEFAULT_KNOB) * (this.MAX_SPEED - DEFAULT_SPEED) / stepsAbove;
+            }
+
+            updateSpeedLabel() {
+                const speed = this.knobToSpeed(this.config.speedKnob);
+                this.elements.currentSpeed.textContent = speed.toFixed(2);
             }
             
             playBounceSound() {
@@ -181,8 +200,7 @@ class DVDCornerChallenge {
                 
                 // Speed slider event listener
                 this.elements.speedSlider.addEventListener('input', (e) => {
-                    this.config.speedMultiplier = parseInt(e.target.value);
-                    this.elements.currentSpeed.textContent = this.config.speedMultiplier;
+                    this.config.speedKnob = parseInt(e.target.value);
                     this.updateSpeeds();
                     this.updatePreviewSpeeds();
                 });
@@ -247,12 +265,10 @@ class DVDCornerChallenge {
             }
             
             updateSpeeds() {
-                // Linear mapping: slider 1 => MIN_SPEED, slider 11 => MAX_SPEED
-                const sliderValue = this.config.speedMultiplier;
-                const maxSlider = 11;
-                const speed = this.MIN_SPEED + (sliderValue - 1) * (this.MAX_SPEED - this.MIN_SPEED) / (maxSlider - 1);
+                const speed = this.knobToSpeed(this.config.speedKnob);
                 this.config.previewSpeed = speed;
                 this.config.gameSpeed = speed;
+                this.updateSpeedLabel();
             }
             
             updateSizes() {


### PR DESCRIPTION
## Summary
- document default knob position in README
- update the speed slider default and label in the HTML
- set default knob to 6 in the game script
- compute knob speed from piecewise interpolation so k6 => 1.0

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446c2552b4832ea224c6d48816ea0c