### PR TITLE
Fix duplicate slider update in initializeGame

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,10 +86,6 @@ class DVDCornerChallenge {
 
                 this.updateSpeeds();
                 this.updateSizes();
-
-                // Sync sliders with configured defaults
-                this.elements.speedSlider.value = this.config.speedKnob;
-                this.elements.currentSpeed.textContent = this.config.speedKnob;
             }
             
             initializeAudio() {


### PR DESCRIPTION
## Summary
- remove redundant speed slider value assignment
- rely on `updateSpeeds()` to update the current speed label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447fccc734832e88eab8be7e29384e