### PR TITLE
Modify speed knob to use discrete presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A neon-soaked browser game inspired by the classic DVD screensaver. Open `index.
 - **Corner Hit Showdown:** First logo to hit any corner wins the round.
 - **Live Logo Preview:** See your logo bounce around as you type your name.
 - **Custom Game Settings:**
-  - **Speed:** Crank it up or slow it down with an 11-position knob (default at 6).
+  - **Speed:** Choose from five preset speeds using the knob (default at 3).
   - **Logo Size:** Make your logo huge or keep it classic (1-5).
 - **Neon Arcade UI:** Flashy, animated buttons and overlays with glowing effects.
 - **Fullscreen Mode:** Go immersive with 'F'.

--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
         </div>
         <div class="controls-container">
             <div class="control-group">
-                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">1</span></div>
+                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">2</span></div>
                 <div class="slider-container">
-                    <input type="range" id="speed-slider" class="game-slider" min="1" max="11" value="6" step="1">
+                    <input type="range" id="speed-slider" class="game-slider" min="1" max="5" value="3" step="1">
                 </div>
             </div>
             <div class="control-group">

--- a/script.js
+++ b/script.js
@@ -1,8 +1,10 @@
 class DVDCornerChallenge {
             constructor() {
-                this.MIN_SPEED = 0.01; // Speed when the knob is at 1
-                this.MAX_SPEED = 20; // Speed when the knob is at 11
-                this.DEFAULT_KNOB = 6; // Default knob position (speed 1)
+                // Discrete speed mapping
+                this.KNOB_POSITIONS = [1, 2, 3, 4, 5];
+                this.SPEED_VALUES = [0.5, 1, 2, 4, 8];
+                // Default knob position (matches an entry in KNOB_POSITIONS)
+                this.DEFAULT_KNOB = 3;
                 this.initializeElements();
                 this.initializeGame();
                 this.setupEventListeners();
@@ -65,7 +67,7 @@ class DVDCornerChallenge {
                 
                 // Game configuration
                 this.config = {
-                    // Slider knob position (1-11)
+                    // Slider knob position (value from KNOB_POSITIONS)
                     speedKnob: this.DEFAULT_KNOB,
                     baseLogo: { width: 200, height: 88 },
                     sizeMultiplier: 3, // Default size (slider value 3)
@@ -80,8 +82,10 @@ class DVDCornerChallenge {
                 
                 // Initialize audio context
                 this.initializeAudio();
-                
+
                 // Sync sliders with configured defaults
+                this.elements.speedSlider.min = this.KNOB_POSITIONS[0];
+                this.elements.speedSlider.max = this.KNOB_POSITIONS[this.KNOB_POSITIONS.length - 1];
                 this.elements.speedSlider.value = this.config.speedKnob;
 
                 this.updateSpeeds();
@@ -115,13 +119,9 @@ class DVDCornerChallenge {
             }
 
             knobToSpeed(k) {
-                const DEFAULT_SPEED = 1;
-                if (k <= this.DEFAULT_KNOB) {
-                    const stepsBelow = this.DEFAULT_KNOB - 1;
-                    return this.MIN_SPEED + (k - 1) * (DEFAULT_SPEED - this.MIN_SPEED) / stepsBelow;
-                }
-                const stepsAbove = 11 - this.DEFAULT_KNOB;
-                return DEFAULT_SPEED + (k - this.DEFAULT_KNOB) * (this.MAX_SPEED - DEFAULT_SPEED) / stepsAbove;
+                const index = this.KNOB_POSITIONS.indexOf(Number(k));
+                const defaultIndex = this.KNOB_POSITIONS.indexOf(this.DEFAULT_KNOB);
+                return index !== -1 ? this.SPEED_VALUES[index] : this.SPEED_VALUES[defaultIndex];
             }
 
             updateSpeedLabel() {


### PR DESCRIPTION
## Summary
- simplify speed knob logic
- map discrete knob positions to preset speeds
- update slider defaults and README instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684488527128832e9af2bb07ab22c0b8