### PR TITLE
Show knob position label

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
         </div>
         <div class="controls-container">
             <div class="control-group">
-                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">2</span></div>
+                <div class="control-label">Game Speed: <span class="control-value" id="current-speed">6</span></div>
                 <div class="slider-container">
-                    <input type="range" id="speed-slider" class="game-slider" min="1" max="5" value="3" step="1">
+                    <input type="range" id="speed-slider" class="game-slider" min="1" max="11" value="6" step="1">
                 </div>
             </div>
             <div class="control-group">

--- a/script.js
+++ b/script.js
@@ -124,9 +124,8 @@ class DVDCornerChallenge {
                 return index !== -1 ? this.SPEED_VALUES[index] : this.SPEED_VALUES[defaultIndex];
             }
 
-            updateSpeedLabel() {
-                const speed = this.knobToSpeed(this.config.speedKnob);
-                this.elements.currentSpeed.textContent = speed.toFixed(2);
+           updateSpeedLabel() {
+                this.elements.currentSpeed.textContent = this.config.speedKnob;
             }
 
             playBounceSound() {


### PR DESCRIPTION
## Summary
- display the knob position instead of the speed value
- match slider defaults to knob positions in HTML

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684490be4d50832e9054b706d388b874