### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>DVD Screensaver Game</title>
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">

--- a/style.css
+++ b/style.css
@@ -787,15 +787,15 @@ body {
 
 @media (max-width: 600px) {
     :root {
-        --button-height: 50px;
-        --button-width: 160px;
+        --button-height: 45px;
+        --button-width: 140px;
         --border-width: 2px;
     }
     .arcade-button {
-        font-size: 14px;
+        font-size: 13px;
     }
     .arcade-button--primary {
-        font-size: 18px;
+        font-size: 16px;
     }
     #fullscreen-btn {
         width: 40px;
@@ -807,29 +807,35 @@ body {
     #stop-game-btn,
     #restart-btn,
     #sound-toggle-btn {
-        width: 160px;
-        min-width: 160px;
-        height: 50px;
-        font-size: 14px;
+        width: 140px;
+        min-width: 140px;
+        height: 45px;
+        font-size: 13px;
     }
     .player-inputs {
         grid-template-columns: 1fr;
+        gap: 15px;
+        margin-bottom: 20px;
+    }
+    .button-container {
+        gap: 20px;
     }
     .controls-container {
         flex-direction: column;
-        gap: 30px;
+        gap: 20px;
+        margin-bottom: 20px;
     }
     .game-slider {
-        width: 180px;
+        width: 160px;
     }
     .control-label,
     .player-input label {
         font-size: 14px;
     }
     .player-input input {
-        width: 180px;
-        padding: 10px 15px;
-        font-size: 14px;
+        width: 160px;
+        padding: 8px 12px;
+        font-size: 13px;
     }
     .control-value {
         font-size: 16px;
@@ -852,42 +858,55 @@ body {
 
 @media (max-width: 400px) {
     :root {
-        --button-height: 40px;
-        --button-width: 120px;
+        --button-height: 35px;
+        --button-width: 100px;
         --border-width: 2px;
     }
     .arcade-button {
-        font-size: 12px;
+        font-size: 11px;
     }
     .arcade-button--primary {
-        font-size: 16px;
+        font-size: 14px;
     }
     #fullscreen-btn {
-        width: 30px;
-        height: 30px;
-        font-size: 10px;
+        width: 26px;
+        height: 26px;
+        font-size: 9px;
     }
     .bottom-buttons button,
     #bottom-action-buttons button,
     #stop-game-btn,
     #restart-btn,
     #sound-toggle-btn {
-        width: 120px;
-        min-width: 120px;
-        height: 40px;
-        font-size: 12px;
+        width: 100px;
+        min-width: 100px;
+        height: 35px;
+        font-size: 11px;
+    }
+    .player-inputs {
+        grid-template-columns: 1fr;
+        gap: 10px;
+        margin-bottom: 15px;
+    }
+    .button-container {
+        gap: 15px;
+    }
+    .controls-container {
+        flex-direction: column;
+        gap: 15px;
+        margin-bottom: 15px;
     }
     .game-slider {
-        width: 140px;
+        width: 120px;
     }
     .control-label,
     .player-input label {
         font-size: 12px;
     }
     .player-input input {
-        width: 150px;
-        padding: 8px 12px;
-        font-size: 12px;
+        width: 130px;
+        padding: 6px 10px;
+        font-size: 11px;
     }
     .control-value {
         font-size: 14px;


### PR DESCRIPTION
## Summary
- shrink layout for mobile with tighter gaps
- disable page zoom to fit mobile screens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844919aa074832e9202dac90b9b2fa8