### PR TITLE
Bring back winner animation and scale name labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,9 +70,11 @@ class DVDCornerChallenge {
                     // Slider knob position (value from KNOB_POSITIONS)
                     speedKnob: this.DEFAULT_KNOB,
                     baseLogo: { width: 200, height: 88 },
+                    baseLabelSize: 12,
                     sizeMultiplier: 3, // Default size (slider value 3)
                     logoWidth: 200,
                     logoHeight: 88,
+                    labelFontSize: 12,
                     playerColors: [
                         '#00ffff', '#ff0080', '#00ff00', '#ffff00', 
                         '#ff4000', '#8000ff', '#ff0040', '#40ff00',
@@ -274,6 +276,8 @@ class DVDCornerChallenge {
                 const scale = window.innerWidth < 400 ? 0.35 : 0.5;
                 this.config.logoWidth = this.config.baseLogo.width * this.config.sizeMultiplier * scale;
                 this.config.logoHeight = this.config.baseLogo.height * this.config.sizeMultiplier * scale;
+                this.config.labelFontSize = this.config.baseLabelSize * this.config.sizeMultiplier;
+                this.updatePlayerLabelSizes();
             }
             
             updatePreviewSpeeds() {
@@ -295,6 +299,13 @@ class DVDCornerChallenge {
                     if (preview) {
                         preview.element.style.width = `${this.config.logoWidth}px`;
                     }
+                });
+            }
+
+            updatePlayerLabelSizes() {
+                const newSize = this.config.labelFontSize;
+                document.querySelectorAll('.player-label').forEach(label => {
+                    label.style.fontSize = `${newSize}px`;
                 });
             }
             
@@ -494,6 +505,10 @@ class DVDCornerChallenge {
                     <div class="player-label">${playerName}</div>
                 `;
                 logoDiv.style.filter = `drop-shadow(0 0 20px ${color}80)`;
+                const label = logoDiv.querySelector('.player-label');
+                if (label) {
+                    label.style.fontSize = `${this.config.labelFontSize}px`;
+                }
                 return logoDiv;
             }
             

--- a/style.css
+++ b/style.css
@@ -695,6 +695,7 @@ body {
     letter-spacing: 6px;
     margin-bottom: 20px;
     text-shadow: 0 0 40px rgba(255, 0, 128, 1);
+    display: inline-block;
     animation: nameFlash 1.5s ease-in-out infinite;
 }
 
@@ -745,16 +746,17 @@ body {
 }
 
 @keyframes nameFlash {
-
     0%,
     100% {
         color: var(--neon-pink);
         text-shadow: 0 0 40px rgba(255, 0, 128, 1);
+        transform: scale(1);
     }
 
     50% {
         color: var(--neon-cyan);
         text-shadow: 0 0 40px rgba(0, 255, 255, 1);
+        transform: scale(1.1);
     }
 }
 


### PR DESCRIPTION
## Summary
- make winner name pulsate and color-cycle again
- scale all player name labels with the selected logo size

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449a67ac74832ebba62b2a9d1dadbe