### PR TITLE
Fix name alignment with scaled logos

### DIFF
--- a/script.js
+++ b/script.js
@@ -306,6 +306,7 @@ class DVDCornerChallenge {
                 const newSize = this.config.labelFontSize;
                 document.querySelectorAll('.player-label').forEach(label => {
                     label.style.fontSize = `${newSize}px`;
+                    label.style.bottom = `-${newSize}px`;
                 });
             }
             
@@ -508,6 +509,7 @@ class DVDCornerChallenge {
                 const label = logoDiv.querySelector('.player-label');
                 if (label) {
                     label.style.fontSize = `${this.config.labelFontSize}px`;
+                    label.style.bottom = `-${this.config.labelFontSize}px`;
                 }
                 return logoDiv;
             }


### PR DESCRIPTION
## Summary
- keep label aligned under DVD logo when the logo size changes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449d2cddbc832e88c822e1bb19aadf