### PR TITLE
Center game UI on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -712,6 +712,7 @@ body {
     letter-spacing: 2px;
     margin-bottom: 30px;
     text-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+    text-align: center;
 }
 
 #winner-logo-display,
@@ -914,7 +915,7 @@ body {
     #game-setup {
         padding-top: 10px;
         padding-bottom: 10px;
-        justify-content: flex-start;
+        justify-content: center;
     }
 }
 
@@ -1005,7 +1006,7 @@ body {
     #game-setup {
         padding-top: 4px;
         padding-bottom: 4px;
-        justify-content: flex-start;
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- keep instructions centered on small screens by setting `#game-setup` to `justify-content: center` in mobile media queries
- center align the end-of-game bounce message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b17023d4832e8fd5de9f13d26d07